### PR TITLE
Bump pyproject TOML version to 3.13 as we use 3.13-only APIs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [{ name = "Kevin Liu", email = "kliu52@student.ubc.ca" },
 ]
 description = "Automatically generate arguments of Python functions."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 classifiers = ["Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Well, it looks like the way use `ast.arguments` is Python3.13 only, and any older versions will not work. This is not great for compatibility with a lot of Python projects. Updating the pyproject.toml to reflect.